### PR TITLE
Implement ball physics and scoring

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,16 @@ type Screen =
 
 function App() {
   const [screen, setScreen] = useState<Screen>({ status: 'disconnected' });
-  const [paddles, setPaddles] = useState<GameState>({ leftPaddleY: 0, rightPaddleY: 0 });
+  const [game, setGame] = useState<GameState>({
+    leftPaddleY: 0,
+    rightPaddleY: 0,
+    ballX: 0,
+    ballY: 0,
+    ballVX: 0,
+    ballVY: 0,
+    leftScore: 0,
+    rightScore: 0,
+  });
 
   useEffect(() => {
     socket.on('handshake', (data) => {
@@ -28,7 +37,7 @@ function App() {
       setScreen({ status: 'room_ready', role: data.role, roomId: data.roomId });
     });
     socket.on('state_tick', (state: GameState) => {
-      setPaddles(state);
+      setGame(state);
     });
     return () => {
       socket.off('handshake');
@@ -64,8 +73,10 @@ function App() {
     content = (
       <div>
         <div>Game starting — you're {screen.role}</div>
-        <div>Left: {paddles.leftPaddleY}</div>
-        <div>Right: {paddles.rightPaddleY}</div>
+        <div>Left: {game.leftPaddleY}</div>
+        <div>Right: {game.rightPaddleY}</div>
+        <div>Ball: {game.ballX}, {game.ballY}</div>
+        <div>Score: {game.leftScore} - {game.rightScore}</div>
       </div>
     );
   }

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -1,16 +1,37 @@
 // GPT: server/src/game.ts
 import type { GameState, Role, PaddleDirection } from '../../shared/types.js';
 
+export const GAME_WIDTH = 600;
+export const GAME_HEIGHT = 400;
+const PADDLE_HEIGHT = 80;
+const PADDLE_OFFSET = 20;
+const BALL_RADIUS = 5;
+const INITIAL_BALL_SPEED_X = 3;
+const INITIAL_BALL_SPEED_Y = 2;
+
 const games: Record<string, GameState> = {};
 
 export function createGame(roomId: string): GameState {
-  const state: GameState = { leftPaddleY: 0, rightPaddleY: 0 };
+  const state: GameState = {
+    leftPaddleY: 0,
+    rightPaddleY: 0,
+    ballX: 0,
+    ballY: 0,
+    ballVX: INITIAL_BALL_SPEED_X,
+    ballVY: INITIAL_BALL_SPEED_Y,
+    leftScore: 0,
+    rightScore: 0,
+  };
   games[roomId] = state;
   return state;
 }
 
 export function getGame(roomId: string): GameState | undefined {
   return games[roomId];
+}
+
+export function getAllGames(): [string, GameState][] {
+  return Object.entries(games);
 }
 
 export function removeGame(roomId: string): void {
@@ -25,8 +46,61 @@ export function applyPaddleMove(
   const step = 5;
   if (role === 'left') {
     state.leftPaddleY += dir === 'up' ? -step : step;
+    state.leftPaddleY = Math.max(
+      -GAME_HEIGHT / 2 + PADDLE_HEIGHT / 2,
+      Math.min(GAME_HEIGHT / 2 - PADDLE_HEIGHT / 2, state.leftPaddleY),
+    );
   } else {
     state.rightPaddleY += dir === 'up' ? -step : step;
+    state.rightPaddleY = Math.max(
+      -GAME_HEIGHT / 2 + PADDLE_HEIGHT / 2,
+      Math.min(GAME_HEIGHT / 2 - PADDLE_HEIGHT / 2, state.rightPaddleY),
+    );
   }
+  return state;
+}
+
+function resetBall(state: GameState, direction: number) {
+  state.ballX = 0;
+  state.ballY = 0;
+  state.ballVX = INITIAL_BALL_SPEED_X * direction;
+  state.ballVY = INITIAL_BALL_SPEED_Y * (Math.random() > 0.5 ? 1 : -1);
+}
+
+export function stepGame(state: GameState): GameState {
+  state.ballX += state.ballVX;
+  state.ballY += state.ballVY;
+
+  if (state.ballY <= -GAME_HEIGHT / 2 + BALL_RADIUS || state.ballY >= GAME_HEIGHT / 2 - BALL_RADIUS) {
+    state.ballVY *= -1;
+  }
+
+  const leftPaddleX = -GAME_WIDTH / 2 + PADDLE_OFFSET;
+  const rightPaddleX = GAME_WIDTH / 2 - PADDLE_OFFSET;
+
+  if (
+    state.ballX - BALL_RADIUS <= leftPaddleX &&
+    state.ballX - BALL_RADIUS >= leftPaddleX - Math.abs(state.ballVX) &&
+    Math.abs(state.ballY - state.leftPaddleY) <= PADDLE_HEIGHT / 2
+  ) {
+    state.ballVX = Math.abs(state.ballVX);
+  }
+
+  if (
+    state.ballX + BALL_RADIUS >= rightPaddleX &&
+    state.ballX + BALL_RADIUS <= rightPaddleX + Math.abs(state.ballVX) &&
+    Math.abs(state.ballY - state.rightPaddleY) <= PADDLE_HEIGHT / 2
+  ) {
+    state.ballVX = -Math.abs(state.ballVX);
+  }
+
+  if (state.ballX < -GAME_WIDTH / 2) {
+    state.rightScore += 1;
+    resetBall(state, -1);
+  } else if (state.ballX > GAME_WIDTH / 2) {
+    state.leftScore += 1;
+    resetBall(state, 1);
+  }
+
   return state;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,14 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import { queuePlayer, removeSocket, getRoomAndRole } from './rooms';
-import { createGame, getGame, applyPaddleMove, removeGame } from './game';
+import {
+  createGame,
+  getGame,
+  getAllGames,
+  applyPaddleMove,
+  removeGame,
+  stepGame,
+} from './game';
 
 const app = express();
 const httpServer = createServer(app);
@@ -52,6 +59,13 @@ io.on('connection', (socket) => {
     console.log('Client disconnected:', socket.id);
   });
 });
+
+setInterval(() => {
+  for (const [roomId, game] of getAllGames()) {
+    stepGame(game);
+    io.to(roomId).emit('state_tick', game);
+  }
+}, 50);
 
 const PORT = 4000;
 httpServer.listen(PORT, () => {

--- a/server/test/collision.spec.ts
+++ b/server/test/collision.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { stepGame, GAME_HEIGHT, GAME_WIDTH } from '../src/game';
+import type { GameState } from '../../shared/types';
+
+function baseState(): GameState {
+  return {
+    leftPaddleY: 0,
+    rightPaddleY: 0,
+    ballX: 0,
+    ballY: 0,
+    ballVX: 1,
+    ballVY: 1,
+    leftScore: 0,
+    rightScore: 0,
+  };
+}
+
+describe('stepGame collision logic', () => {
+  it('bounces off top wall', () => {
+    const state = baseState();
+    state.ballY = GAME_HEIGHT / 2 - 1;
+    state.ballVY = 2;
+    stepGame(state);
+    expect(state.ballVY).toBe(-2);
+  });
+
+  it('increments score when ball passes right wall', () => {
+    const state = baseState();
+    state.ballX = GAME_WIDTH / 2 + 1;
+    stepGame(state);
+    expect(state.leftScore).toBe(1);
+    expect(state.ballX).toBe(0);
+  });
+
+  it('bounces off left paddle', () => {
+    const state = baseState();
+    state.ballX = -GAME_WIDTH / 2 + 26; // near left paddle and moving left
+    state.ballVX = -2;
+    stepGame(state);
+    expect(state.ballVX).toBeGreaterThan(0);
+  });
+});

--- a/server/test/game.spec.ts
+++ b/server/test/game.spec.ts
@@ -5,7 +5,16 @@ import type { GameState } from '../../shared/types';
 
 describe('applyPaddleMove', () => {
   it('moves left paddle up and down', () => {
-    const state: GameState = { leftPaddleY: 0, rightPaddleY: 0 };
+    const state: GameState = {
+      leftPaddleY: 0,
+      rightPaddleY: 0,
+      ballX: 0,
+      ballY: 0,
+      ballVX: 0,
+      ballVY: 0,
+      leftScore: 0,
+      rightScore: 0,
+    };
     applyPaddleMove(state, 'left', 'up');
     expect(state.leftPaddleY).toBe(-5);
     applyPaddleMove(state, 'left', 'down');
@@ -13,7 +22,16 @@ describe('applyPaddleMove', () => {
   });
 
   it('moves right paddle', () => {
-    const state: GameState = { leftPaddleY: 0, rightPaddleY: 0 };
+    const state: GameState = {
+      leftPaddleY: 0,
+      rightPaddleY: 0,
+      ballX: 0,
+      ballY: 0,
+      ballVX: 0,
+      ballVY: 0,
+      leftScore: 0,
+      rightScore: 0,
+    };
     applyPaddleMove(state, 'right', 'down');
     expect(state.rightPaddleY).toBe(5);
   });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -15,6 +15,12 @@ export interface PaddleMovePayload {
 export interface GameState {
   leftPaddleY: number;
   rightPaddleY: number;
+  ballX: number;
+  ballY: number;
+  ballVX: number;
+  ballVY: number;
+  leftScore: number;
+  rightScore: number;
 }
 
 export interface ServerToClientEvents {


### PR DESCRIPTION
## Summary
- add ball physics and scores to `GameState`
- update server game logic for movement, collisions and scoring
- broadcast state ticks continuously
- render ball position and scores in the React client
- test new collision logic

## Testing
- `pnpm exec vitest run`
- `pnpm exec tsc -p server`
- `pnpm exec tsc -p client`


------
https://chatgpt.com/codex/tasks/task_e_684213b76bb08325834f362309d67d69