### PR TITLE
Fix server state logic and test suite

### DIFF
--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -1,8 +1,8 @@
 // GPT: server/src/game.ts
 import type { GameState, Role, PaddleDirection } from '../../shared/types.js';
 
-const GAME_HEIGHT = 400;
-const GAME_WIDTH = 600;
+export const GAME_HEIGHT = 400;
+export const GAME_WIDTH = 600;
 const PADDLE_HEIGHT = 80;
 const PADDLE_OFFSET = 20;
 const BALL_RADIUS = 5;

--- a/server/src/rooms.ts
+++ b/server/src/rooms.ts
@@ -50,5 +50,12 @@ function getRoomAndRole(socketId: string): { roomId: string; role: Role } | null
   return { roomId, role };
 }
 
-export { queuePlayer, removeSocket, getRoomAndRole };
+// Helper used in tests to reset all in-memory state
+function __testReset(): void {
+  queue.length = 0;
+  Object.keys(rooms).forEach((k) => delete rooms[k]);
+  Object.keys(socketToRoom).forEach((k) => delete socketToRoom[k]);
+}
+
+export { queuePlayer, removeSocket, getRoomAndRole, __testReset };
 

--- a/server/test/game.spec.ts
+++ b/server/test/game.spec.ts
@@ -1,38 +1,23 @@
-// GPT: server/test/game.spec.ts
 import { describe, it, expect } from 'vitest';
 import { applyPaddleMove } from '../src/game';
 import type { GameState } from '../../shared/types';
 
 describe('applyPaddleMove', () => {
+  function blankState(): GameState {
+    return {
+      leftPaddleY: 0,
+      rightPaddleY: 0,
+      ballX: 0,
+      ballY: 0,
+      ballVX: 0,
+      ballVY: 0,
+      leftScore: 0,
+      rightScore: 0,
+    };
+  }
+
   it('moves left paddle up and down', () => {
-    const state: GameState = {
-      leftPaddleY: 0,
-      rightPaddleY: 0,
-      ballX: 0,
-      ballY: 0,
-      ballVX: 0,
-      ballVY: 0,
-      leftScore: 0,
-      rightScore: 0,
-    };
-    const state: GameState = {
-      leftPaddleY: 0,
-      rightPaddleY: 0,
-      ballX: 0,
-      ballY: 0,
-      ballVX: 0,
-      ballVY: 0,
-      leftScore: 0,
-      rightScore: 0,
-    };
-      rightPaddleY: 0,
-      ballX: 0,
-      ballY: 0,
-      ballVX: 0,
-      ballVY: 0,
-      leftScore: 0,
-      rightScore: 0,
-    };
+    const state = blankState();
     applyPaddleMove(state, 'left', 'up');
     expect(state.leftPaddleY).toBe(-5);
     applyPaddleMove(state, 'left', 'down');
@@ -40,16 +25,7 @@ describe('applyPaddleMove', () => {
   });
 
   it('moves right paddle', () => {
-    const state: GameState = {
-      leftPaddleY: 0,
-      rightPaddleY: 0,
-      ballX: 0,
-      ballY: 0,
-      ballVX: 0,
-      ballVY: 0,
-      leftScore: 0,
-      rightScore: 0,
-    };
+    const state = blankState();
     applyPaddleMove(state, 'right', 'down');
     expect(state.rightPaddleY).toBe(5);
   });

--- a/server/test/rooms.spec.ts
+++ b/server/test/rooms.spec.ts
@@ -3,18 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   queuePlayer,
   removeSocket,
-} from '../src/rooms.js';
-
-// Test utilities
-const queue: string[] = [];
-const rooms: Record<string, { left: string; right: string }> = {};
-const socketToRoom: Record<string, string> = {};
-
-function __testReset() {
-  queue.length = 0;
-  Object.keys(rooms).forEach(key => delete rooms[key]);
-  Object.keys(socketToRoom).forEach(key => delete socketToRoom[key]);
-}
+  __testReset,
+} from '../src/rooms';
 
 describe('rooms.ts pure logic', () => {
   beforeEach(() => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -21,12 +21,6 @@ export interface GameState {
   ballVY: number;
   leftScore: number;
   rightScore: number;
-  ballX: number;
-  ballY: number;
-  ballVX: number;
-  ballVY: number;
-  leftScore: number;
-  rightScore: number;
 }
 
 export interface ServerToClientEvents {


### PR DESCRIPTION
## Summary
- remove duplicate fields from shared GameState interface
- export `GAME_HEIGHT` and `GAME_WIDTH` so tests can import them
- add `__testReset` helper for room state management
- clean up server unit tests

## Testing
- `pnpm exec tsc -p server`
- `pnpm exec tsc -p client`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6842e762eadc83258f8de750e371f83e