### PR TITLE
Add logging for state tick events

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,6 +70,7 @@ setInterval(() => {
   for (const [roomId, game] of getAllGames()) {
     stepGame(game);
     io.to(roomId).emit('state_tick', game);
+    console.log('Emitting state_tick for', roomId, game);
   }
 }, 50);
 


### PR DESCRIPTION
## Summary
- add console log within the server's game loop to debug `state_tick` emissions

## Testing
- `pnpm test` *(fails: waiting for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec4ec79083258315859cc9f902b1