### PR TITLE
Add canvas rendering for game state

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { io as ClientIO } from 'socket.io-client';
 import type { GameState } from '../../shared/types';
+import GameCanvas from './GameCanvas';
 
 const socket = ClientIO('http://localhost:4000');
 
@@ -73,10 +74,10 @@ function App() {
     content = (
       <div>
         <div>Game starting — you're {screen.role}</div>
-        <div>Left: {game.leftPaddleY}</div>
-        <div>Right: {game.rightPaddleY}</div>
-        <div>Ball: {game.ballX}, {game.ballY}</div>
-        <div>Score: {game.leftScore} - {game.rightScore}</div>
+        <GameCanvas state={game} />
+        <div style={{ marginTop: '1rem' }}>
+          Score: {game.leftScore} - {game.rightScore}
+        </div>
       </div>
     );
   }

--- a/client/src/GameCanvas.tsx
+++ b/client/src/GameCanvas.tsx
@@ -1,0 +1,64 @@
+import { useRef, useEffect } from 'react';
+import type { GameState } from '../../shared/types';
+import {
+  GAME_WIDTH,
+  GAME_HEIGHT,
+  PADDLE_HEIGHT,
+  PADDLE_WIDTH,
+  BALL_RADIUS,
+  PADDLE_OFFSET,
+} from './constants';
+
+interface Props {
+  state: GameState;
+}
+
+export default function GameCanvas({ state }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
+    ctx.fillStyle = 'white';
+
+    // left paddle
+    ctx.fillRect(
+      PADDLE_OFFSET,
+      GAME_HEIGHT / 2 + state.leftPaddleY - PADDLE_HEIGHT / 2,
+      PADDLE_WIDTH,
+      PADDLE_HEIGHT,
+    );
+
+    // right paddle
+    ctx.fillRect(
+      GAME_WIDTH - PADDLE_OFFSET - PADDLE_WIDTH,
+      GAME_HEIGHT / 2 + state.rightPaddleY - PADDLE_HEIGHT / 2,
+      PADDLE_WIDTH,
+      PADDLE_HEIGHT,
+    );
+
+    // ball
+    ctx.beginPath();
+    ctx.arc(
+      GAME_WIDTH / 2 + state.ballX,
+      GAME_HEIGHT / 2 + state.ballY,
+      BALL_RADIUS,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }, [state]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={GAME_WIDTH}
+      height={GAME_HEIGHT}
+      style={{ backgroundColor: 'black' }}
+    />
+  );
+}

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,6 @@
+export const GAME_WIDTH = 600;
+export const GAME_HEIGHT = 400;
+export const PADDLE_HEIGHT = 80;
+export const PADDLE_WIDTH = 10;
+export const BALL_RADIUS = 5;
+export const PADDLE_OFFSET = 20;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,9 +42,12 @@ io.on('connection', (socket) => {
     // Notify both clients
     const { roomId, left, right } = result;
     if (left && right) {
+      io.sockets.sockets.get(left)?.join(roomId);
+      io.sockets.sockets.get(right)?.join(roomId);
       io.to(left).emit('room_ready', { roomId, role: 'left' });
       io.to(right).emit('room_ready', { roomId, role: 'right' });
-      createGame(roomId);
+      const game = createGame(roomId);
+      io.to(roomId).emit('state_tick', game);
     }
   }
 
@@ -70,6 +73,7 @@ setInterval(() => {
   for (const [roomId, game] of getAllGames()) {
     stepGame(game);
     io.to(roomId).emit('state_tick', game);
+    console.log('Emitting state_tick for', roomId, game);
   }
 }, 50);
 


### PR DESCRIPTION
## Summary
- add game constants for the client
- implement `GameCanvas` to draw paddles and ball
- display the canvas in the `room_ready` screen
- join paired players to their room and emit the initial state

## Testing
- `pnpm exec vitest run`
- `pnpm exec tsc -p client`
- `pnpm exec tsc -p server`


------
https://chatgpt.com/codex/tasks/task_e_6842ec4ec79083258315859cc9f902b1